### PR TITLE
Allow disabling of the File list API calls

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -10,7 +10,8 @@ exports.config = {
 			},
 			user: 'user-to-watch',
 			repo: 'repo_name',
-			frequency: 15000
+			frequency: 15000,
+			skip_file_listing: false
 		},
 		jenkins:  {
 			token: 'token',

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -30,7 +30,12 @@ exports.init = function(config, mergeatron) {
 							continue;
 						}
 
-						checkFiles(pull);
+						if (config.skip_file_listing) {
+							pull.files = [];
+							mergeatron.emit('pull.found', pull);
+						} else {
+							checkFiles(pull);
+						}
 					}
 				});
 


### PR DESCRIPTION
For our usage, the listinf of the files wasn't necessary and we often
have a large number of files and changes in commits so it was kinda a
waste.
