### PR TITLE
Update the github, jenkins, and db plugins for extensibility

### DIFF
--- a/bin/github_setup.js
+++ b/bin/github_setup.js
@@ -29,7 +29,8 @@ rl.question('Please enter the URL of the webhook', function(hook_url) {
 					}
 				},
 				headers: {
-					authorization: 'Basic ' + (new Buffer(auth, 'ascii').toString('base64'))
+					authorization: 'Basic ' + (new Buffer(auth, 'ascii').toString('base64')),
+					'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0'
 				}
 			};
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -8,7 +8,8 @@ exports.config = {
 			host: 'localhost',
 			port: 27017
 		},
-		database: 'mergeatron'
+		database: 'mergeatron',
+		collections: [ 'pulls' ]
 	},
 	log_level: 'info',
 	plugin_dirs: [ './plugins/' ],

--- a/db.js
+++ b/db.js
@@ -5,7 +5,7 @@ exports.init = function() {
 
 	// mongo abstraction layer
 	var MongoDB = function() {
-		this.connection = require('mongojs').connect(config.database, ['pulls']);
+		this.connection = require('mongojs').connect(config.database, config.collections);
 	};
 
 	// pull methods

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"name": "mergeatron",
 	"description": "A helpful PR monitor that runs jenkins builds when Pull Requests are created and updated",
 	"author": "SNAP Interactive, Inc.",
@@ -27,7 +27,8 @@
 		"node-uuid": ">=1.3.3",
 		"async": ">=0.1.22",
 		"winston": ">=0.6.2",
-		"xml2js": ">=0.2.2"
+		"xml2js": ">=0.2.2",
+		"range_check": "*"
 	},
 
 	"devDependencies": {

--- a/plugins/jenkins.js
+++ b/plugins/jenkins.js
@@ -98,34 +98,19 @@ Jenkins.prototype.setup = function() {
 Jenkins.prototype.buildPull = function(pull, number, sha, ssh_url, branch, updated_at) {
 	var project = this.findProjectByRepo(pull.repo),
 		job_id = uuid.v1(),
-		options = {
-			url: url.format({
-				protocol: this.config.protocol,
-				host: this.config.host,
-				pathname: '/job/' + project.name + '/buildWithParameters',
-				query: {
-					token: project.token,
-					cause: 'Testing Pull Request: ' + number,
-					REPOSITORY_URL: ssh_url,
-					BRANCH_NAME: branch,
-					JOB: job_id,
-					PULL: number,
-					BASE_BRANCH_NAME: pull.base.ref
-				}
-			}),
-			method: 'GET'
-		};
-
-	if (this.config.user && this.config.pass) {
-		options.headers = {
-			authorization: 'Basic ' + (new Buffer(this.config.user + ":" + this.config.pass, 'ascii').toString('base64'))
-		};
-	}
+		self = this;
 
 	this.mergeatron.log.info('Starting build for pull', { pull_number: pull.number, project: project.name });
 
-	var self = this;
-	request(options, function(error) {
+	this.triggerBuild(project.name, {
+		token: project.token,
+		cause: 'Testing Pull Request: ' + number,
+		REPOSITORY_URL: ssh_url,
+		BRANCH_NAME: branch,
+		JOB: job_id,
+		PULL: number,
+		BASE_BRANCH_NAME: pull.base.ref
+	}, function(error) {
 		if (error) {
 			self.mergeatron.log.error(error);
 			return;
@@ -189,28 +174,11 @@ Jenkins.prototype.pullFound = function(pull) {
 Jenkins.prototype.checkJob = function(pull) {
 	var self = this,
 		job = this.findUnfinishedJob(pull),
-		project = this.findProjectByRepo(pull.repo),
-		options = {
-			url: url.format({
-				protocol: this.config.protocol,
-				host: this.config.host,
-				pathname: '/job/' + project.name + '/api/json',
-				query: {
-					tree: 'builds[number,url,actions[parameters[name,value]],building,result]'
-				}
-			}),
-			json: true
-		};
+		project = this.findProjectByRepo(pull.repo);
 
-	if (this.config.user && this.config.pass) {
-		options.headers = {
-			authorization: 'Basic ' + (new Buffer(this.config.user + ":" + this.config.pass, 'ascii').toString('base64'))
-		};
-	}
-
-	request(options, function(error, response) {
+	this.checkBuild(project.name, function(error, response) {
 		if (error) {
-			self.mergeatron.log.error('could not connect to jenkins, there seems to be a connectivity issue!');
+			self.mergeatron.log.error('Could not connect to jenkins, there seems to be a connectivity issue!');
 			return;
 		}
 
@@ -231,12 +199,12 @@ Jenkins.prototype.checkJob = function(pull) {
 							self.mergeatron.db.updateJobStatus(job.id, 'finished');
 							self.mergeatron.emit('build.failed', job, pull, build.url + 'console');
 
-							self.processArtifacts(build, pull);
+							self.processArtifacts(project.name, build, pull);
 						} else if (build.result == 'SUCCESS') {
 							self.mergeatron.db.updateJobStatus(job.id, 'finished');
 							self.mergeatron.emit('build.succeeded', job, pull, build.url);
 
-							self.processArtifacts(build, pull);
+							self.processArtifacts(project.name, build, pull);
 						} else if (build.result == 'ABORTED') {
 							self.mergeatron.db.updateJobStatus(job.id, 'finished');
 							self.mergeatron.emit('build.aborted', job, pull, build.url);
@@ -249,20 +217,80 @@ Jenkins.prototype.checkJob = function(pull) {
 };
 
 /**
+ * Makes a GET request to the Jenkins API to start a build
+ *
+ * @method triggerBuild
+ * @param job_name {String}
+ * @param url_options {Options}
+ * @param callback {Function}
+ */
+Jenkins.prototype.triggerBuild = function(job_name, url_options, callback) {
+	var options = {
+		url: url.format({
+			protocol: this.config.protocol,
+			host: this.config.host,
+			pathname: '/job/' + job_name + '/buildWithParameters',
+			query: url_options
+		}),
+		method: 'GET'
+	};
+
+	if (this.config.user && this.config.pass) {
+		options.headers = {
+			authorization: 'Basic ' + (new Buffer(this.config.user + ":" + this.config.pass, 'ascii').toString('base64'))
+		};
+	}
+
+	request(options, callback);
+};
+
+/**
+ * Checks the Jenkins API for the status of a job
+ *
+ * @method checkBuild
+ * @param job_name {String}
+ * @param callback {Function}
+ */
+Jenkins.prototype.checkBuild = function(job_name, callback) {
+	var self = this,
+		options = {
+			url: url.format({
+				protocol: this.config.protocol,
+				host: this.config.host,
+				pathname: '/job/' + job_name + '/api/json',
+				query: {
+					tree: 'builds[number,url,actions[parameters[name,value]],building,result]'
+				}
+			}),
+			json: true
+		};
+
+	if (this.config.user && this.config.pass) {
+		options.headers = {
+			authorization: 'Basic ' + (new Buffer(this.config.user + ":" + this.config.pass, 'ascii').toString('base64'))
+		};
+	}
+
+	request(options, function(error, response) {
+		callback(error, response, self.mergeatron);
+	});
+};
+
+/**
  * Downloads the artifact list for a build and dispatches an event for each one. This lets other
  * plugins parse and process results from the build however they like.
  *
  * @method processArtifacts
+ * @param job_name {String}
  * @param build {String}
  * @param pull {Object}
  */
-Jenkins.prototype.processArtifacts = function(build, pull) {
-	var project = this.findProjectByRepo(pull.repo),
-		options = {
+Jenkins.prototype.processArtifacts = function(job_name, build, pull) {
+	var options = {
 		url: url.format({
 			protocol: this.config.protocol,
 			host: this.config.host,
-			pathname: '/job/' + project.name + '/' + build.number + '/api/json',
+			pathname: '/job/' + job_name + '/' + build.number + '/api/json',
 			query: {
 				tree: 'artifacts[fileName,relativePath]'
 			}
@@ -283,10 +311,10 @@ Jenkins.prototype.processArtifacts = function(build, pull) {
 			return;
 		}
 
-		self.mergeatron.log.debug('Retrieved artifacts for build', { build: build.number, project: project.name });
+		self.mergeatron.log.debug('Retrieved artifacts for build', { build: build.number, project: job_name });
 
 		response.body.artifacts.forEach(function(artifact) {
-			artifact.url = self.config.protocol + '://' + self.config.host + '/job/' + project.name + '/' + build.number + '/artifact/' + artifact.relativePath;
+			artifact.url = self.config.protocol + '://' + self.config.host + '/job/' + job_name + '/' + build.number + '/artifact/' + artifact.relativePath;
 
 			self.mergeatron.log.debug('Found artifact for build', { build: build.number, url: artifact.url });
 			self.mergeatron.emit('build.artifact_found', build, pull, artifact);
@@ -336,5 +364,21 @@ exports.init = function(config, mergeatron) {
 
 	mergeatron.on('build.download_artifact', function(build, pull, artifact) {
 		jenkins.downloadArtifact(build, pull, artifact);
+	});
+
+	mergeatron.on('build.trigger', function(job_name, url_options) {
+		jenkins.triggerBuild(job_name, url_options, function(error) {
+			if (error) {
+				mergeatron.log.info('Received error from Jenkins when triggering build', { job_name: job_name, url_options: url_options });
+			}
+		});
+	});
+
+	mergeatron.on('build.check', function(job_name, callback) {
+		jenkins.checkBuild(job_name, callback);
+	});
+
+	mergeatron.on('process_artifacts', function(job_name, build, pull) {
+		jenkins.processArtifacts(job_name, build, pull);
 	});
 };


### PR DESCRIPTION
Mergeatron allows loading external, custom, plugins outside of the main ones. These changes make the built-in plugins more extensible by breaking out some of their more core functionality into separate events.

To-do:
- [x] Update GitHub, Jenkins, and DB plugins
- [ ] Update accompanying documentation 
